### PR TITLE
Ensure CRC helper indexes rx_buf safely

### DIFF
--- a/src/modbus_controller.v
+++ b/src/modbus_controller.v
@@ -99,13 +99,12 @@ module modbus_controller #(
 
   // ----- helper functions -----
   function [15:0] crc16_sw;
-    input integer n;
+    input [7:0] n;
     integer i0,j0; reg [15:0] c0; reg [7:0] d0;
     begin
-      c0        = 16'hFFFF;
-      crc16_sw  = 16'h0000;
+      c0 = 16'hFFFF;
       for (i0=0;i0<n;i0=i0+1) begin
-        d0 = rx_buf[i0];
+        d0 = rx_buf[i0[7:0]];
         for (j0=0;j0<8;j0=j0+1) begin
           if (((c0^d0) & 16'h0001)!=16'h0000) c0=(c0>>1)^16'hA001; else c0=(c0>>1);
           d0 = d0 >> 1;


### PR DESCRIPTION
## Summary
- Limit CRC software function to 8-bit length and mask buffer index to stay within rx_buf bounds

## Testing
- `iverilog -g2012 -Isrc -o build/top_tb tb/top_modbus_converter_tb.v src/*.v`
- `vvp build/top_tb`
