### PR TITLE
Fix modbus controller loops for synthesis

### DIFF
--- a/src/modbus_controller.v
+++ b/src/modbus_controller.v
@@ -63,8 +63,8 @@ module modbus_controller #(
 
   // ===== TX buffer (per-frame) =====
   reg [7:0] tx_buf [0:255];
-  reg [7:0] tx_len;
-  reg [7:0] tx_idx;
+  reg [8:0] tx_len;
+  reg [8:0] tx_idx;
 
   // ===== Shared temporaries =====
   integer i,j,k,bitn,ofs,base;
@@ -103,11 +103,13 @@ module modbus_controller #(
     integer i0,j0; reg [15:0] c0; reg [7:0] d0;
     begin
       c0 = 16'hFFFF;
-      for (i0=0;i0<n;i0=i0+1) begin
-        d0 = rx_buf[i0[7:0]];
-        for (j0=0;j0<8;j0=j0+1) begin
-          if (((c0^d0) & 16'h0001)!=16'h0000) c0=(c0>>1)^16'hA001; else c0=(c0>>1);
-          d0 = d0 >> 1;
+      for (i0=0;i0<256;i0=i0+1) begin
+        if (i0 < n) begin
+          d0 = rx_buf[i0[7:0]];
+          for (j0=0;j0<8;j0=j0+1) begin
+            if (((c0^d0) & 16'h0001)!=16'h0000) c0=(c0>>1)^16'hA001; else c0=(c0>>1);
+            d0 = d0 >> 1;
+          end
         end
       end
       crc16_sw = c0;
@@ -130,8 +132,8 @@ module modbus_controller #(
     if (rst) begin
       st <= S_IDLE;
       rx_len <= 8'd0;
-      tx_idx <= 8'd0;
-      tx_len <= 8'd0;
+      tx_idx <= 9'd0;
+      tx_len <= 9'd0;
       tx_b_v <= 1'b0;
 
       do_we    <= 1'b0;
@@ -260,173 +262,193 @@ module modbus_controller #(
           // Master: treat inbound as response; update images.
           if (!cfg_mode_master) begin
             // ---------- SLAVE ----------
-            if (func==8'h01 || func==8'h02) begin
-              // read coils/discretes
-              bytes  = (qty + 16'd7) >> 3;
-              tx_len = 8'd0;
+              if (func==8'h01 || func==8'h02) begin
+                // read coils/discretes
+                bytes  = (qty + 16'd7) >> 3;
+                tx_len = 9'd0;
 
-              // resp: addr func bytecount data... crc
-              tx_buf[tx_len] = dev_addr; tx_len = tx_len + 1;
-              tx_buf[tx_len] = func;     tx_len = tx_len + 1;
-              tx_buf[tx_len] = bytes[7:0]; tx_len = tx_len + 1;
+                // resp: addr func bytecount data... crc
+                tx_buf[tx_len[7:0]] = dev_addr; tx_len = tx_len + 9'd1;
+                tx_buf[tx_len[7:0]] = func;     tx_len = tx_len + 9'd1;
+                tx_buf[tx_len[7:0]] = bytes[7:0]; tx_len = tx_len + 9'd1;
 
-              for (i=0; i<bytes; i=i+1) begin
-                b = 8'h00;
-                for (bitn=0; bitn<8; bitn=bitn+1) begin
-                  if ((i*8+bitn) < qty) begin
-                    if (func==8'h01) b[bitn] = ((do_wdata >> (addr + i*8 + bitn)) & 1'b1);
-                    else             b[bitn] = ((di_status >> (addr + i*8 + bitn)) & 1'b1);
+                for (i=0; i<256; i=i+1) begin
+                  if (i < bytes) begin
+                    b = 8'h00;
+                    for (bitn=0; bitn<8; bitn=bitn+1) begin
+                      if ((i*8+bitn) < qty) begin
+                        if (func==8'h01) b[bitn] = ((do_wdata >> (addr + i*8 + bitn)) & 1'b1);
+                        else             b[bitn] = ((di_status >> (addr + i*8 + bitn)) & 1'b1);
+                      end
+                    end
+                    tx_buf[tx_len[7:0]] = b; tx_len = tx_len + 9'd1;
                   end
                 end
-                tx_buf[tx_len] = b; tx_len = tx_len + 1;
-              end
 
-              // CRC
-              c = 16'hFFFF;
-              for (j=0; j<tx_len; j=j+1) begin
-                x = c ^ tx_buf[j];
-                for (k=0; k<8; k=k+1) begin
-                  if (x[0]) x = (x>>1) ^ 16'hA001; else x = (x>>1);
-                end
-                c = x;
-              end
-              tx_buf[tx_len] = c[7:0];  tx_len = tx_len + 1;
-              tx_buf[tx_len] = c[15:8]; tx_len = tx_len + 1;
-
-              st <= S_SEND; tx_idx <= 8'd0;
-
-            end else if (func==8'h03 || func==8'h04) begin
-              // read holding/input regs
-              tx_len = 8'd0;
-              tx_buf[tx_len] = dev_addr; tx_len = tx_len + 1;
-              tx_buf[tx_len] = func;     tx_len = tx_len + 1;
-
-              tmp8 = (qty << 1);                 // avoid (qty<<1)[7:0]
-              tx_buf[tx_len] = tmp8; tx_len = tx_len + 1;
-
-              for (i=0; i<qty; i=i+1) begin
-                if (func==8'h03) w = reg_holding[(addr + i) - cfg_map_base_qw_iw];
-                else             w = reg_input  [(addr + i) - cfg_map_base_qw_iw];
-                tx_buf[tx_len] = w[15:8]; tx_len = tx_len + 1;
-                tx_buf[tx_len] = w[7:0];  tx_len = tx_len + 1;
-              end
-
-              // CRC
-              c = 16'hFFFF;
-              for (j=0; j<tx_len; j=j+1) begin
-                x = c ^ tx_buf[j];
-                for (k=0; k<8; k=k+1) x = x[0] ? ((x>>1)^16'hA001) : (x>>1);
-                c = x;
-              end
-              tx_buf[tx_len] = c[7:0];  tx_len = tx_len + 1;
-              tx_buf[tx_len] = c[15:8]; tx_len = tx_len + 1;
-
-              st <= S_SEND; tx_idx <= 8'd0;
-
-            end else if (func==8'h05) begin
-              // write single coil: echo request
-              do_wmask <= (32'h1 << addr[4:0]);
-              do_wdata <= (val==16'hFF00) ? (32'h1 << addr[4:0]) : 32'h0;
-              do_we    <= 1'b1;
-
-              tx_len = 8'd0;
-              for (j=0; j<6; j=j+1) begin
-                tx_buf[tx_len] = rx_buf[j]; tx_len = tx_len + 1;
-              end
-
-              c = 16'hFFFF;
-              for (j=0; j<tx_len; j=j+1) begin
-                x = c ^ tx_buf[j];
-                for (k=0; k<8; k=k+1) x = x[0] ? ((x>>1)^16'hA001) : (x>>1);
-                c = x;
-              end
-              tx_buf[tx_len] = c[7:0];  tx_len = tx_len + 1;
-              tx_buf[tx_len] = c[15:8]; tx_len = tx_len + 1;
-
-              st <= S_SEND; tx_idx <= 8'd0;
-
-            end else if (func==8'h06) begin
-              // write single holding reg
-              reg_holding[addr - cfg_map_base_qw_iw] <= val;
-
-              tx_len = 8'd0;
-              for (j=0; j<6; j=j+1) begin
-                tx_buf[tx_len] = rx_buf[j]; tx_len = tx_len + 1;
-              end
-
-              c = 16'hFFFF;
-              for (j=0; j<tx_len; j=j+1) begin
-                x = c ^ tx_buf[j];
-                for (k=0; k<8; k=k+1) x = x[0] ? ((x>>1)^16'hA001) : (x>>1);
-                c = x;
-              end
-              tx_buf[tx_len] = c[7:0];  tx_len = tx_len + 1;
-              tx_buf[tx_len] = c[15:8]; tx_len = tx_len + 1;
-
-              st <= S_SEND; tx_idx <= 8'd0;
-
-            end else if (func==8'h0F) begin
-              // write multiple coils: unpack data starting rx_buf[7..7+byte_count-1]
-              new_do = 32'h0;
-              msk    = 32'h0;
-              for (i=0; i<byte_count; i=i+1) begin
-                for (bitn=0; bitn<8; bitn=bitn+1) begin
-                  if ((i*8+bitn) < qty) begin
-                    msk[addr + i*8 + bitn]    = 1'b1;
-                    new_do[addr + i*8 + bitn] = rx_buf[7+i][bitn];
+                // CRC
+                c = 16'hFFFF;
+                for (j=0; j<256; j=j+1) begin
+                  if (j < tx_len) begin
+                    x = c ^ tx_buf[j];
+                    for (k=0; k<8; k=k+1) begin
+                      if (x[0]) x = (x>>1) ^ 16'hA001; else x = (x>>1);
+                    end
+                    c = x;
                   end
                 end
-              end
-              do_wmask <= msk;
-              do_wdata <= new_do;
-              do_we    <= 1'b1;
+                tx_buf[tx_len[7:0]] = c[7:0];  tx_len = tx_len + 9'd1;
+                tx_buf[tx_len[7:0]] = c[15:8]; tx_len = tx_len + 9'd1;
 
-              // Response: echo addr func start qty
-              tx_len = 8'd0;
-              tx_buf[tx_len] = dev_addr; tx_len = tx_len + 1;
-              tx_buf[tx_len] = func;     tx_len = tx_len + 1;
-              tx_buf[tx_len] = rx_buf[2]; tx_len = tx_len + 1;
-              tx_buf[tx_len] = rx_buf[3]; tx_len = tx_len + 1;
-              tx_buf[tx_len] = rx_buf[4]; tx_len = tx_len + 1;
-              tx_buf[tx_len] = rx_buf[5]; tx_len = tx_len + 1;
+                st <= S_SEND; tx_idx <= 9'd0;
 
-              c = 16'hFFFF;
-              for (j=0; j<tx_len; j=j+1) begin
-                x = c ^ tx_buf[j];
-                for (k=0; k<8; k=k+1) x = x[0] ? ((x>>1)^16'hA001) : (x>>1);
-                c = x;
-              end
-              tx_buf[tx_len] = c[7:0];  tx_len = tx_len + 1;
-              tx_buf[tx_len] = c[15:8]; tx_len = tx_len + 1;
+              end else if (func==8'h03 || func==8'h04) begin
+                // read holding/input regs
+                tx_len = 9'd0;
+                tx_buf[tx_len[7:0]] = dev_addr; tx_len = tx_len + 9'd1;
+                tx_buf[tx_len[7:0]] = func;     tx_len = tx_len + 9'd1;
 
-              st <= S_SEND; tx_idx <= 8'd0;
+                tmp8 = (qty << 1);                 // avoid (qty<<1)[7:0]
+                tx_buf[tx_len[7:0]] = tmp8; tx_len = tx_len + 9'd1;
 
-            end else if (func==8'h10) begin
-              // write multiple holding regs: unpack words from rx_buf[7..]
-              for (i=0; i<qty; i=i+1) begin
-                w = {rx_buf[7+i*2], rx_buf[8+i*2]};
-                reg_holding[(addr + i) - cfg_map_base_qw_iw] <= w;
-              end
+                for (i=0; i<REG_WORDS; i=i+1) begin
+                  if (i < qty) begin
+                    if (func==8'h03) w = reg_holding[(addr + i) - cfg_map_base_qw_iw];
+                    else             w = reg_input  [(addr + i) - cfg_map_base_qw_iw];
+                    tx_buf[tx_len[7:0]] = w[15:8]; tx_len = tx_len + 9'd1;
+                    tx_buf[tx_len[7:0]] = w[7:0];  tx_len = tx_len + 9'd1;
+                  end
+                end
 
-              // Response: echo addr func start qty
-              tx_len = 8'd0;
-              tx_buf[tx_len] = dev_addr; tx_len = tx_len + 1;
-              tx_buf[tx_len] = func;     tx_len = tx_len + 1;
-              tx_buf[tx_len] = rx_buf[2]; tx_len = tx_len + 1;
-              tx_buf[tx_len] = rx_buf[3]; tx_len = tx_len + 1;
-              tx_buf[tx_len] = rx_buf[4]; tx_len = tx_len + 1;
-              tx_buf[tx_len] = rx_buf[5]; tx_len = tx_len + 1;
+                // CRC
+                c = 16'hFFFF;
+                for (j=0; j<256; j=j+1) begin
+                  if (j < tx_len) begin
+                    x = c ^ tx_buf[j];
+                    for (k=0; k<8; k=k+1) x = x[0] ? ((x>>1)^16'hA001) : (x>>1);
+                    c = x;
+                  end
+                end
+                tx_buf[tx_len[7:0]] = c[7:0];  tx_len = tx_len + 9'd1;
+                tx_buf[tx_len[7:0]] = c[15:8]; tx_len = tx_len + 9'd1;
 
-              c = 16'hFFFF;
-              for (j=0; j<tx_len; j=j+1) begin
-                x = c ^ tx_buf[j];
-                for (k=0; k<8; k=k+1) x = x[0] ? ((x>>1)^16'hA001) : (x>>1);
-                c = x;
-              end
-              tx_buf[tx_len] = c[7:0];  tx_len = tx_len + 1;
-              tx_buf[tx_len] = c[15:8]; tx_len = tx_len + 1;
+                st <= S_SEND; tx_idx <= 9'd0;
 
-              st <= S_SEND; tx_idx <= 8'd0;
+              end else if (func==8'h05) begin
+                // write single coil: echo request
+                do_wmask <= (32'h1 << addr[4:0]);
+                do_wdata <= (val==16'hFF00) ? (32'h1 << addr[4:0]) : 32'h0;
+                do_we    <= 1'b1;
+
+                tx_len = 9'd0;
+                for (j=0; j<6; j=j+1) begin
+                  tx_buf[tx_len[7:0]] = rx_buf[j]; tx_len = tx_len + 9'd1;
+                end
+
+                c = 16'hFFFF;
+                for (j=0; j<256; j=j+1) begin
+                  if (j < tx_len) begin
+                    x = c ^ tx_buf[j];
+                    for (k=0; k<8; k=k+1) x = x[0] ? ((x>>1)^16'hA001) : (x>>1);
+                    c = x;
+                  end
+                end
+                tx_buf[tx_len[7:0]] = c[7:0];  tx_len = tx_len + 9'd1;
+                tx_buf[tx_len[7:0]] = c[15:8]; tx_len = tx_len + 9'd1;
+
+                st <= S_SEND; tx_idx <= 9'd0;
+
+              end else if (func==8'h06) begin
+                // write single holding reg
+                reg_holding[addr - cfg_map_base_qw_iw] <= val;
+
+                tx_len = 9'd0;
+                for (j=0; j<6; j=j+1) begin
+                  tx_buf[tx_len[7:0]] = rx_buf[j]; tx_len = tx_len + 9'd1;
+                end
+
+                c = 16'hFFFF;
+                for (j=0; j<256; j=j+1) begin
+                  if (j < tx_len) begin
+                    x = c ^ tx_buf[j];
+                    for (k=0; k<8; k=k+1) x = x[0] ? ((x>>1)^16'hA001) : (x>>1);
+                    c = x;
+                  end
+                end
+                tx_buf[tx_len[7:0]] = c[7:0];  tx_len = tx_len + 9'd1;
+                tx_buf[tx_len[7:0]] = c[15:8]; tx_len = tx_len + 9'd1;
+
+                st <= S_SEND; tx_idx <= 9'd0;
+
+              end else if (func==8'h0F) begin
+                // write multiple coils: unpack data starting rx_buf[7..7+byte_count-1]
+                new_do = 32'h0;
+                msk    = 32'h0;
+                for (i=0; i<32; i=i+1) begin
+                  if (i < byte_count) begin
+                    for (bitn=0; bitn<8; bitn=bitn+1) begin
+                      if ((i*8+bitn) < qty) begin
+                        msk[addr + i*8 + bitn]    = 1'b1;
+                        new_do[addr + i*8 + bitn] = rx_buf[7+i][bitn];
+                      end
+                    end
+                  end
+                end
+                do_wmask <= msk;
+                do_wdata <= new_do;
+                do_we    <= 1'b1;
+
+                // Response: echo addr func start qty
+                tx_len = 9'd0;
+                tx_buf[tx_len[7:0]] = dev_addr; tx_len = tx_len + 9'd1;
+                tx_buf[tx_len[7:0]] = func;     tx_len = tx_len + 9'd1;
+                tx_buf[tx_len[7:0]] = rx_buf[2]; tx_len = tx_len + 9'd1;
+                tx_buf[tx_len[7:0]] = rx_buf[3]; tx_len = tx_len + 9'd1;
+                tx_buf[tx_len[7:0]] = rx_buf[4]; tx_len = tx_len + 9'd1;
+                tx_buf[tx_len[7:0]] = rx_buf[5]; tx_len = tx_len + 9'd1;
+
+                c = 16'hFFFF;
+                for (j=0; j<256; j=j+1) begin
+                  if (j < tx_len) begin
+                    x = c ^ tx_buf[j];
+                    for (k=0; k<8; k=k+1) x = x[0] ? ((x>>1)^16'hA001) : (x>>1);
+                    c = x;
+                  end
+                end
+                tx_buf[tx_len[7:0]] = c[7:0];  tx_len = tx_len + 9'd1;
+                tx_buf[tx_len[7:0]] = c[15:8]; tx_len = tx_len + 9'd1;
+
+                st <= S_SEND; tx_idx <= 9'd0;
+
+              end else if (func==8'h10) begin
+                // write multiple holding regs: unpack words from rx_buf[7..]
+                for (i=0; i<REG_WORDS; i=i+1) begin
+                  if (i < qty) begin
+                    w = {rx_buf[7+i*2], rx_buf[8+i*2]};
+                    reg_holding[(addr + i) - cfg_map_base_qw_iw] <= w;
+                  end
+                end
+
+                // Response: echo addr func start qty
+                tx_len = 9'd0;
+                tx_buf[tx_len[7:0]] = dev_addr; tx_len = tx_len + 9'd1;
+                tx_buf[tx_len[7:0]] = func;     tx_len = tx_len + 9'd1;
+                tx_buf[tx_len[7:0]] = rx_buf[2]; tx_len = tx_len + 9'd1;
+                tx_buf[tx_len[7:0]] = rx_buf[3]; tx_len = tx_len + 9'd1;
+                tx_buf[tx_len[7:0]] = rx_buf[4]; tx_len = tx_len + 9'd1;
+                tx_buf[tx_len[7:0]] = rx_buf[5]; tx_len = tx_len + 9'd1;
+
+                c = 16'hFFFF;
+                for (j=0; j<256; j=j+1) begin
+                  if (j < tx_len) begin
+                    x = c ^ tx_buf[j];
+                    for (k=0; k<8; k=k+1) x = x[0] ? ((x>>1)^16'hA001) : (x>>1);
+                    c = x;
+                  end
+                end
+                tx_buf[tx_len[7:0]] = c[7:0];  tx_len = tx_len + 9'd1;
+                tx_buf[tx_len[7:0]] = c[15:8]; tx_len = tx_len + 9'd1;
+
+                st <= S_SEND; tx_idx <= 9'd0;
 
             end else begin
               st <= S_IDLE;
@@ -439,13 +461,15 @@ module modbus_controller #(
               st <= S_IDLE;
             end
 
-            else if (func==8'h03 || func==8'h04) begin
-              base = scan_rbase;
-              for (i=0; i<qty; i=i+1) begin
-                w = {rx_buf[3+i*2], rx_buf[4+i*2]};
-                reg_input[base + i] <= w;
-              end
-              st <= S_IDLE;
+              else if (func==8'h03 || func==8'h04) begin
+                base = scan_rbase;
+                for (i=0; i<REG_WORDS; i=i+1) begin
+                  if (i < qty) begin
+                    w = {rx_buf[3+i*2], rx_buf[4+i*2]};
+                    reg_input[base + i] <= w;
+                  end
+                end
+                st <= S_IDLE;
 
             end else begin
               st <= S_IDLE;
@@ -454,16 +478,16 @@ module modbus_controller #(
         end
 
         // =========================
-        S_SEND: begin
-          if (tx_b_rdy && (tx_idx < tx_len)) begin
-            tx_b   <= tx_buf[tx_idx];
-            tx_b_v <= 1'b1;
-            tx_idx <= tx_idx + 8'd1;
+          S_SEND: begin
+            if (tx_b_rdy && (tx_idx < tx_len)) begin
+              tx_b   <= tx_buf[tx_idx[7:0]];
+              tx_b_v <= 1'b1;
+              tx_idx <= tx_idx + 9'd1;
+            end
+            if (tx_idx == tx_len) begin
+              st <= S_IDLE;
+            end
           end
-          if (tx_idx == tx_len) begin
-            st <= S_IDLE;
-          end
-        end
 
         default: begin
           st <= S_IDLE;


### PR DESCRIPTION
## Summary
- Rewrite variable-length loops with fixed bounds and conditional checks to satisfy synthesizer
- Widen TX length/index counters to 9 bits to avoid truncation
- Replace CRC helper with fixed-iteration version

## Testing
- `iverilog -g2012 -o OneKiwi_PLC/tb/testbench.vvp OneKiwi_PLC/tb/top_modbus_converter_tb.v OneKiwi_PLC/src/*.v`
- `vvp OneKiwi_PLC/tb/testbench.vvp`


------
https://chatgpt.com/codex/tasks/task_e_689da9e6bdbc832db8bb51af66f89fa3