### PR TITLE
Expose TX empty status for testing

### DIFF
--- a/src/top_modbus_converter.v
+++ b/src/top_modbus_converter.v
@@ -57,6 +57,14 @@ module top_modbus_converter #(
   wire [15:0] cfg_map_base_qw_iw;
 
   wire        stat_crc_err, stat_lrc_err, stat_frame_to;
+  reg         stat_tx_empty;
+
+  always @(posedge PCLK) begin
+    if (rst)
+      stat_tx_empty <= 1'b1;
+    else
+      stat_tx_empty <= 1'b1;
+  end
 
   // Scan CSRs
   wire        scan_en;
@@ -80,7 +88,7 @@ module top_modbus_converter #(
     .cfg_ascii_en(cfg_ascii_en), .cfg_rtu_sil_q88(cfg_rtu_sil_q88),
     .cfg_baud_div(cfg_baud_div), .cfg_msg_wm(cfg_msg_wm), .cfg_map_base_qw_iw(cfg_map_base_qw_iw),
     .stat_crc_err(stat_crc_err), .stat_lrc_err(stat_lrc_err), .stat_frame_to(stat_frame_to),
-    .stat_tx_empty(1'b1), .stat_rx_avail(csr_rx_valid),
+    .stat_tx_empty(stat_tx_empty), .stat_rx_avail(csr_rx_valid),
     .irq_w1c(irq_w1c),
 
     .scan_en(scan_en), .scan_retry_max(scan_retry_max), .scan_period_ms(scan_period_ms),

--- a/tb/top_modbus_converter_tb.v
+++ b/tb/top_modbus_converter_tb.v
@@ -118,11 +118,11 @@ module top_modbus_converter_tb;
     // --- IRQ W1C ---
     apb_write(12'h01C, 32'hFFFF_FFFF);
     apb_read(12'h01C, rddata); if (rddata !== 32'h0000_0002) begin $display("ERROR: IRQ W1C %h", rddata); $finish; end
-    force dut.u_csr.stat_tx_empty = 1'b0;
+    force dut.stat_tx_empty = 1'b0;
     @(posedge PCLK);
     apb_write(12'h01C, 32'h0000_0002);
     apb_read(12'h01C, rddata); if (rddata !== 32'h0000_0000) begin $display("ERROR: IRQ clear %h", rddata); $finish; end
-    release dut.u_csr.stat_tx_empty;
+    release dut.stat_tx_empty;
 
     // --- Scan control/table registers ---
     apb_write(12'h020, 32'h0000_0101);


### PR DESCRIPTION
## Summary
- drive CSR `stat_tx_empty` via a register so the testbench can override it
- update the testbench to force/release the top-level TX empty signal instead of the CSR input

## Testing
- `verilator --lint-only --timing -Wno-TIMESCALEMOD -Wno-INITIALDLY src/*.v tb/top_modbus_converter_tb.v`
- `iverilog -g2001 -s top_modbus_converter_tb -o build/top_modbus_converter_tb.vvp src/*.v tb/top_modbus_converter_tb.v`
- `vvp build/top_modbus_converter_tb.vvp`
