### PR TITLE
Refactor testbench assignments and tidy RTL formatting

### DIFF
--- a/src/crc16_modbus.v
+++ b/src/crc16_modbus.v
@@ -10,8 +10,10 @@ module crc16_modbus(
   reg [15:0] c;
   /* verilator lint_off BLKSEQ */
   function [15:0] step;
-    input [15:0] cin; input [7:0] d;
-    integer i; reg [15:0] x;
+    input [15:0] cin;
+    input [7:0]  d;
+    integer i;
+    reg [15:0] x;
     begin
       // Extend incoming byte to 16 bits before XOR to avoid width mismatch
       x = cin ^ {8'h00, d};

--- a/src/csr_block.v
+++ b/src/csr_block.v
@@ -173,7 +173,8 @@ assign timer_cnt = reg02_timer;
 
   // Writes
   function [31:0] wb;
-    input [31:0] oldv, newv; input [3:0] st;
+    input [31:0] oldv, newv;
+    input [3:0] st;
     begin
       wb = oldv;
       if (st[0]) wb[ 7:0 ] = newv[ 7:0 ];
@@ -189,7 +190,9 @@ assign timer_cnt = reg02_timer;
       reg04_cfg0 <= 32'h0001_0000; // Master=1, parity=None, stop=1, ASCII=0, sil=1
       reg05_cfg1 <= 32'h0080_0036; // wm=0x80, baud_div=54 (~115200 @ 100MHz/16)
       reg06_map  <= 32'h0;
-      tx_push    <= 1'b0; rx_pop <= 1'b0; tx_data<=8'h00;
+        tx_push    <= 1'b0;
+        rx_pop     <= 1'b0;
+        tx_data    <= 8'h00;
 
       // scan defaults
       reg08_scan_ctrl <= 32'h0001_0014; // en=1, retry_max=1, period=20ms
@@ -200,13 +203,17 @@ assign timer_cnt = reg02_timer;
       reg0d_scan_wbase<= 32'h0;
       reg0e_scan_rbase<= 32'h0;
     end else begin
-      tx_push <= 1'b0; rx_pop <= 1'b0;
+        tx_push <= 1'b0;
+        rx_pop  <= 1'b0;
 
       if (wr) begin
         case (PADDR[5:2])
           4'h0: reg00_do <= wb(reg00_do, PWDATA, PSTRB);
          
-          4'h3: if (tx_ready) begin tx_data <= PWDATA[7:0]; tx_push<=1'b1; end
+            4'h3: if (tx_ready) begin
+              tx_data <= PWDATA[7:0];
+              tx_push <= 1'b1;
+            end
           4'h4: reg04_cfg0 <= wb(reg04_cfg0, PWDATA, PSTRB);
           4'h5: reg05_cfg1 <= wb(reg05_cfg1, PWDATA, PSTRB);
           4'h6: reg06_map  <= wb(reg06_map , PWDATA, PSTRB);

--- a/src/gpio_input.v
+++ b/src/gpio_input.v
@@ -7,9 +7,17 @@ module gpio_input #(
   input  wire [WIDTH-1:0] gpio_i,
   output reg  [WIDTH-1:0] di_status
 );
-  reg [WIDTH-1:0] s1, s2;
+  reg [WIDTH-1:0] s1;
+  reg [WIDTH-1:0] s2;
   always @(posedge clk) begin
-    if (rst) begin s1<=0; s2<=0; di_status<=0; end
-    else begin s1<=gpio_i; s2<=s1; di_status<=s2; end
+    if (rst) begin
+      s1 <= 0;
+      s2 <= 0;
+      di_status <= 0;
+    end else begin
+      s1 <= gpio_i;
+      s2 <= s1;
+      di_status <= s2;
+    end
   end
 endmodule

--- a/src/top_modbus_converter.v
+++ b/src/top_modbus_converter.v
@@ -27,9 +27,12 @@ module top_modbus_converter #(
 );
   // sync reset
   reg [1:0] rff;
-  always @(posedge PCLK or negedge PRESETn) begin
-    if (!PRESETn) rff<=2'b00; else rff<={rff[0],1'b1};
-  end
+    always @(posedge PCLK or negedge PRESETn) begin
+      if (!PRESETn)
+        rff <= 2'b00;
+      else
+        rff <= {rff[0],1'b1};
+    end
   wire rst = ~rff[1];
 
   // Wires between blocks
@@ -100,7 +103,9 @@ module top_modbus_converter #(
 
   gpio_input  u_gpio_in(.clk(PCLK), .rst(rst), .gpio_i(GPIO_DI), .di_status(di_status));
 
-  wire [31:0] do_wdata, do_wmask; wire do_we;
+    wire [31:0] do_wdata;
+    wire [31:0] do_wmask;
+    wire        do_we;
   gpio_output u_gpio_out(.clk(PCLK), .rst(rst), .do_wdata(do_wdata), .do_wmask(do_wmask), .do_we(do_we), .gpio_o(GPIO_DO));
 
   // UART bridge

--- a/src/uart_tx.v
+++ b/src/uart_tx.v
@@ -14,54 +14,99 @@ module uart_tx #(
 );
   localparam [2:0] S_IDLE=3'd0, S_START=3'd1, S_DATA=3'd2, S_PAR=3'd3, S_STOP=3'd4;
   reg [2:0]  st;
-  reg [15:0] div; reg tick;
-  reg [7:0]  os; reg [2:0] bitn;
-  reg [7:0]  sh; reg par_acc;
+  reg [15:0] div;
+  reg        tick;
+  reg [7:0]  os;
+  reg [2:0]  bitn;
+  reg [7:0]  sh;
+  reg        par_acc;
 
   always @(posedge clk) begin
-    if (rst) begin div<=16'd0; tick<=1'b0; end
-    else begin
-      tick<=1'b0;
-      if (div==16'd0) begin div<=baud_div; tick<=1'b1; end
-      else div<=div-16'd1;
+    if (rst) begin
+      div <= 16'd0;
+      tick <= 1'b0;
+    end else begin
+      tick <= 1'b0;
+      if (div == 16'd0) begin
+        div <= baud_div;
+        tick <= 1'b1;
+      end else begin
+        div <= div - 16'd1;
+      end
     end
   end
 
   always @(posedge clk) begin
     if (rst) begin
-      st<=S_IDLE; tx_o<=1'b1; ready_o<=1'b1; os<=8'd0; bitn<=3'd0; sh<=8'd0; par_acc<=1'b0;
+      st <= S_IDLE;
+      tx_o <= 1'b1;
+      ready_o <= 1'b1;
+      os <= 8'd0;
+      bitn <= 3'd0;
+      sh <= 8'd0;
+      par_acc <= 1'b0;
     end else if (tick) begin
       case (st)
         S_IDLE: begin
-          tx_o<=1'b1; ready_o<=1'b1;
+          tx_o <= 1'b1;
+          ready_o <= 1'b1;
           if (valid_i) begin
-            ready_o<=1'b0; sh<=data_i; par_acc<=^data_i; st<=S_START; os<=OVERSAMPLE-8'd1; tx_o<=1'b0;
+            ready_o <= 1'b0;
+            sh <= data_i;
+            par_acc <= ^data_i;
+            st <= S_START;
+            os <= OVERSAMPLE - 8'd1;
+            tx_o <= 1'b0;
           end
         end
         S_START: begin
-          if (os==8'd0) begin st<=S_DATA; os<=OVERSAMPLE-8'd1; bitn<=3'd0; end else os<=os-8'd1;
+          if (os == 8'd0) begin
+            st <= S_DATA;
+            os <= OVERSAMPLE - 8'd1;
+            bitn <= 3'd0;
+          end else begin
+            os <= os - 8'd1;
+          end
         end
         S_DATA: begin
-          tx_o<=sh[0];
-          if (os==8'd0) begin
+          tx_o <= sh[0];
+          if (os == 8'd0) begin
             sh <= {1'b0, sh[7:1]};
-            os<=OVERSAMPLE-8'd1;
-            if (bitn==3'd7) begin
-              if (parity==2'd0) st<=S_STOP; else st<=S_PAR;
+            os <= OVERSAMPLE - 8'd1;
+            if (bitn == 3'd7) begin
+              if (parity == 2'd0)
+                st <= S_STOP;
+              else
+                st <= S_PAR;
             end
-            bitn<=bitn+3'd1;
-          end else os<=os-8'd1;
+            bitn <= bitn + 3'd1;
+          end else begin
+            os <= os - 8'd1;
+          end
         end
         S_PAR: begin
-          tx_o <= (parity==2'd1) ? par_acc : ~par_acc;
-          if (os==8'd0) begin st<=S_STOP; os<=OVERSAMPLE-8'd1; end else os<=os-8'd1;
+          tx_o <= (parity == 2'd1) ? par_acc : ~par_acc;
+          if (os == 8'd0) begin
+            st <= S_STOP;
+            os <= OVERSAMPLE - 8'd1;
+          end else begin
+            os <= os - 8'd1;
+          end
         end
         S_STOP: begin
-          tx_o<=1'b1;
-          if (os==8'd0) begin
-            if (stop2) begin os<=OVERSAMPLE-8'd1; st<=S_IDLE; ready_o<=1'b1; end
-            else begin st<=S_IDLE; ready_o<=1'b1; end
-          end else os<=os-8'd1;
+          tx_o <= 1'b1;
+          if (os == 8'd0) begin
+            if (stop2) begin
+              os <= OVERSAMPLE - 8'd1;
+              st <= S_IDLE;
+              ready_o <= 1'b1;
+            end else begin
+              st <= S_IDLE;
+              ready_o <= 1'b1;
+            end
+          end else begin
+            os <= os - 8'd1;
+          end
         end
         default: begin
           st <= S_IDLE;

--- a/tb/top_modbus_converter_tb.v
+++ b/tb/top_modbus_converter_tb.v
@@ -96,7 +96,7 @@ module top_modbus_converter_tb;
 
     // --- Drive GPIO_DI and read DI ---
     GPIO_DI = 32'hA5A55A5A;
-    repeat (2) @(posedge PCLK);
+    repeat (3) @(posedge PCLK);
     apb_read(12'h004, rddata); if (rddata !== 32'hA5A55A5A) begin $display("ERROR: DI read %h", rddata); $finish; end
 
     // --- Timer write and verify increment ---
@@ -148,53 +148,53 @@ module top_modbus_converter_tb;
   // APB write task
   task apb_write(input [11:0] addr, input [31:0] data);
   begin
+    PADDR  = addr;
+    PWDATA = data;
+    PWRITE = 1'b1;
+    PSEL   = 1'b1;
+    PSTRB  = 4'hF;
     @(posedge PCLK);
-    PADDR  <= addr;
-    PWDATA <= data;
-    PWRITE <= 1'b1;
-    PSEL   <= 1'b1;
-    PSTRB  <= 4'hF;
-    @(posedge PCLK);
-    PENABLE <= 1'b1;
+    PENABLE = 1'b1;
     while (!PREADY) @(posedge PCLK);
-    PSEL   <= 1'b0;
-    PENABLE<= 1'b0;
-    PWRITE <= 1'b0;
+    @(posedge PCLK);
+    PSEL   = 1'b0;
+    PENABLE = 1'b0;
+    PWRITE = 1'b0;
   end
   endtask
 
   // APB masked write task
   task apb_write_masked(input [11:0] addr, input [31:0] data, input [3:0] mask);
   begin
+    PADDR  = addr;
+    PWDATA = data;
+    PWRITE = 1'b1;
+    PSEL   = 1'b1;
+    PSTRB  = mask;
     @(posedge PCLK);
-    PADDR  <= addr;
-    PWDATA <= data;
-    PWRITE <= 1'b1;
-    PSEL   <= 1'b1;
-    PSTRB  <= mask;
-    @(posedge PCLK);
-    PENABLE <= 1'b1;
+    PENABLE = 1'b1;
     while (!PREADY) @(posedge PCLK);
-    PSEL   <= 1'b0;
-    PENABLE<= 1'b0;
-    PWRITE <= 1'b0;
+    @(posedge PCLK);
+    PSEL   = 1'b0;
+    PENABLE = 1'b0;
+    PWRITE = 1'b0;
   end
   endtask
 
   // APB read task
   task apb_read(input [11:0] addr, output [31:0] data);
   begin
+    PADDR  = addr;
+    PWRITE = 1'b0;
+    PSEL   = 1'b1;
+    PSTRB  = 4'h0;
     @(posedge PCLK);
-    PADDR  <= addr;
-    PWRITE <= 1'b0;
-    PSEL   <= 1'b1;
-    PSTRB  <= 4'h0;
-    @(posedge PCLK);
-    PENABLE <= 1'b1;
+    PENABLE = 1'b1;
     while (!PREADY) @(posedge PCLK);
     data = PRDATA;
-    PSEL   <= 1'b0;
-    PENABLE<= 1'b0;
+    @(posedge PCLK);
+    PSEL   = 1'b0;
+    PENABLE = 1'b0;
   end
   endtask
 endmodule


### PR DESCRIPTION
## Summary
- Replace non-blocking assignments in APB helper tasks with blocking ones and adjust timing
- Split combined statements across RTL modules (uart_rx, uart_tx, gpio_input, etc.) for one-statement-per-line style
- Wait three cycles when sampling GPIO inputs in the testbench for synchronizer latency

## Testing
- `verilator --lint-only --timing -Wno-TIMESCALEMOD src/*.v tb/top_modbus_converter_tb.v`
- `iverilog -o sim.out src/*.v tb/top_modbus_converter_tb.v`
- `vvp sim.out`
