### PR TITLE
docs: include Modbus diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Modbus Converter IP core linking a Linux host running OpenPLC to external
 Modbus devices and on-board GPIO. The design is written in plain
 Verilog‑2001 and organized for use in FPGA or ASIC flows.
 
+![Modbus architecture diagram](MODBUS.png)
+
 ## Overview
 
 OneKiwi_PLC bridges an APB3 CSR interface, UART-connected Modbus devices


### PR DESCRIPTION
## Summary
- display Modbus architecture diagram in README for quick visual reference

## Testing
- `verilator --lint-only src/*.v`
- `iverilog -g2001 -s top_modbus_converter_tb -o build/top_modbus_converter_tb.vvp src/*.v tb/top_modbus_converter_tb.v`
- `vvp build/top_modbus_converter_tb.vvp`
