### PR TITLE
Mirror Modbus GPIO writes into CSR

### DIFF
--- a/src/csr_block.v
+++ b/src/csr_block.v
@@ -53,6 +53,9 @@ module csr_block #(
   // DO/DI
   input  wire [31:0] di_status_in,
   output reg  [31:0] do_control_out,
+  input  wire [31:0] do_wdata_ext,
+  input  wire [31:0] do_wmask_ext,
+  input  wire        do_we_ext,
 
   // Timer
   output      [31:0] timer_cnt,
@@ -206,10 +209,13 @@ assign timer_cnt = reg02_timer;
         tx_push <= 1'b0;
         rx_pop  <= 1'b0;
 
+      if (do_we_ext)
+        reg00_do <= (reg00_do & ~do_wmask_ext) | (do_wdata_ext & do_wmask_ext);
+
       if (wr) begin
         case (PADDR[5:2])
           4'h0: reg00_do <= wb(reg00_do, PWDATA, PSTRB);
-         
+
             4'h3: if (tx_ready) begin
               tx_data <= PWDATA[7:0];
               tx_push <= 1'b1;

--- a/src/top_modbus_converter.v
+++ b/src/top_modbus_converter.v
@@ -84,6 +84,7 @@ module top_modbus_converter #(
     .PADDR(PADDR), .PSEL(PSEL), .PENABLE(PENABLE), .PWRITE(PWRITE),
     .PWDATA(PWDATA), .PSTRB(PSTRB), .PRDATA(PRDATA), .PREADY(PREADY), .PSLVERR(PSLVERR),
     .di_status_in(di_status), .do_control_out(do_control),
+    .do_wdata_ext(do_wdata), .do_wmask_ext(do_wmask), .do_we_ext(do_we),
     .timer_cnt(timer_cnt),
     .rx_data(csr_rx_data), .rx_valid(csr_rx_valid), .rx_pop(csr_rx_pop),
     .tx_data(csr_tx_data), .tx_push(csr_tx_push), .tx_ready(csr_tx_ready),


### PR DESCRIPTION
## Summary
- mirror Modbus controller GPIO writes into CSR DO register
- expose external DO write ports on CSR block and connect in top-level

## Testing
- `verilator --lint-only src/*.v`
- `iverilog -g2005-sv -o tb/simv tb/top_modbus_converter_tb.v src/*.v && vvp tb/simv`


------
https://chatgpt.com/codex/tasks/task_e_68a0a5afcd94832d9df3220d4b978b84